### PR TITLE
Make target object per-instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-J# JSON-Patch-Queue [![Build Status](https://travis-ci.org/Palindrom/JSON-Patch-Queue.svg?branch=master)](https://travis-ci.org/Palindrom/JSON-Patch-Queue)
+# JSON-Patch-Queue [![Build Status](https://travis-ci.org/Palindrom/JSON-Patch-Queue.svg?branch=master)](https://travis-ci.org/Palindrom/JSON-Patch-Queue)
 
 > Makes your JSON Patch application sequential
 
@@ -31,22 +31,27 @@ Or [download as ZIP](https://github.com/Palindrom/JSON-Patch-Queue/archive/maste
 
 ### Single Versioned
 ```javascript
+
+var targetObject = {};
 // create queue
-var myQueue = new JSONPatchQueueSynchronous("/path_to_version", jsonpatch);
+var myQueue = new JSONPatchQueueSynchronous(targetObject, "/path_to_version", jsonpatch);
 // to compose versioned JSON Patch, to be send somewhere?
 var versionedPatchToBeSent = myQueue.send(regularpatch);
 // to apply/queue received versioned  JSON Patch
-myQueue.receive(myObject, receivedVersionedPatch);
+myQueue.receive(receivedVersionedPatch);
 ```
 
 ### Multiple Versioned
 ```javascript
+
+var targetObject = {};
+
 // create queue
-var myQueue = new JSONPatchQueue(["/local_version", "/remote_version"], jsonpatch);
+var myQueue = new JSONPatchQueue(targetObject, ["/local_version", "/remote_version"], jsonpatch);
 // to compose versioned JSON Patch, to be send somewhere?
 var versionedPatchToBeSent = myQueue.send(regularpatch);
 // to apply/queue received versioned  JSON Patch
-myQueue.receive(myObject, receivedVersionedPatch);
+myQueue.receive(receivedVersionedPatch);
 ```
 
 ## Requirements
@@ -58,31 +63,32 @@ Agent requires a function to apply JSON Patch, we suggest [fast JSON Patch](http
 Name      | Arguments                     | Default | Description
 ---       | ---                           | ---     | ---
 `send`    | *JSONPatch* sequence          |         | Changes given JSON Patch to Versioned JSON Patch
-`receive` |                               |         | Receives, and eventually applies given Versioned JSON Patch, to the object
-          | *Object* obj                  |         | object to be changed
-          | *VersionedJSONPatch* sequence |         | Versioned JSON Patch to be queued and applied
+`receive` | *VersionedJSONPatch* sequence Versioned JSON Patch to be queued and applied |         | Receives, and eventually applies given Versioned JSON Patch, to the object passed in the constructor
 
 #### Multiple Versioned
 
 Name                         | Arguments            | Default | Description
 ---                          | ---                  | ---     | ---
-`JSONPatchQueue`  | *Array* *JSONPointer* [localVersionPath, remoteVersionPath] |         | Paths where to store the versions
-                             | *Function* apply     |         | `function(object, patch)` function to apply JSON Patch
-                             | *Boolean* purist     | `false` | set to `true` to enable pure/unoptimized Versioned JSON Patch convention
+`JSONPatchQueue`             | *`Object`* obj     | ---     | Target object where patches are applied
+                             | *`Array<JSONPointer>`* `[localVersionPath, remoteVersionPath]` |         | Paths where to store the versions
+                             | *`Function`* apply     |         | `function(object, patch)` function to apply JSON Patch, must return the object in its final state
+                             | *`Boolean`* purist     | `false` | set to `true` to enable pure/unoptimized Versioned JSON Patch convention
 
 #### Single Versioned
 
 Name                         | Arguments            | Default | Description
 ---                          | ---                  | ---     | ---
-`JSONPatchQueueSynchronous`  | *JSONPointer* versionPath |         | Path where to store the version
-                             | *Function* apply     |         | `function(object, patch)` function to apply JSON Patch
-                             | *Boolean* purist     | `false` | set to `true` to enable pure/unoptimized Versioned JSON Patch convention
+`JSONPatchQueueSynchronous`  | *`Object`* *obj*       |         | Target object where patches are applied
+                             | *`JSONPointer`* versionPath |         | Path where to store the version
+                             | *`Function`* apply     |         | `function(object, patch)` function to apply JSON Patch, must return the object in its final
+                             | *`Boolean`* purist     | `false` | set to `true` to enable pure/unoptimized Versioned JSON Patch convention
 
 ## Properties
 
 Name      | Type                          | Description
 ---       | ---                           | ---
-`waiting` | *Array* *JSONPatch*           | Array of JSON Patches waiting in queue
+`obj    ` | *`Object`*                    | Target object where patches are applied
+`waiting` | *`Array<JSONPatch>`*          | Array of JSON Patches waiting in queue
 
 #### Multiple Versioned
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ export class JSONPatchQueueSynchronous {
     /**
      * JSON Patch Queue for synchronous operations, and asynchronous networking.
      * version: 2.0.1
+     * @param {Object} Obj The target object where patches are applied
      * @param {JSON-Pointer} versionPath JSON-Pointers to version numbers
      * @param {function} apply    apply(JSONobj, JSONPatchSequence) function to apply JSONPatch to object.
      * @param {Boolean} [purist]       If set to true adds test operation before replace.
@@ -12,11 +13,10 @@ export class JSONPatchQueueSynchronous {
     /**
     * Process received versioned JSON Patch.
     * Applies or adds to queue.
-    * @param  {Object} obj                   object to apply patches to
     * @param  {JSONPatch} versionedJsonPatch patch to be applied
     * @param  {Function} [applyCallback]     optional `function(object, consecutivePatch)` to be called when applied, if not given #apply will be called
     */
-    public receive(obj: Object, versionedJsonPatch: Object, applyCallback: Function);
+    public receive(versionedJsonPatch: Object, applyCallback: Function);
 
     /**
     * Wraps JSON Patch sequence with version related operation objects
@@ -38,12 +38,13 @@ export class JSONPatchQueueSynchronous {
 export class JSONPatchQueue {
     /**
      * JSON Patch Queue for asynchronous operations, and asynchronous networking.
+     * @param {Object} Obj The target object where patches are applied
      * @param {Array<JSON-Pointer>} versionPaths JSON-Pointers to version numbers [local, remote]
      * @param {function} apply    apply(JSONobj, JSONPatchSequence) function to apply JSONPatch to object.
      * @param {Boolean} [purist]       If set to true adds test operation before replace.
      * @version: 1.0.0
      */
-    constructor(versionPaths: String, apply: Function, purist: Boolean);
+    constructor(obj: Object, versionPaths: String, apply: Function, purist: Boolean);
 
     /** local version */
     public localVersion: Number;
@@ -54,11 +55,10 @@ export class JSONPatchQueue {
     /**
      * Process received versioned JSON Patch
      * Applies or adds to queue.
-     * @param  {Object} obj                   object to apply patches to
      * @param  {JSONPatch} versionedJsonPatch patch to be applied
      * @param  {Function} [applyCallback]     optional `function(object, consecutivePatch)` to be called when applied, if not given #apply will be called
      */
-    public receive(obj: Object, versionedJsonPatch: Object, applyCallback: Function);
+    public receive(versionedJsonPatch: Object, applyCallback: Function);
 
     /**
      * Wraps JSON Patch sequence with version related operation objects
@@ -73,5 +73,5 @@ export class JSONPatchQueue {
      * @param obj object to apply new state to
      * @param newState versioned object representing desired state along with versions
      */
-    public reset(obj: Object, newState: Object);
+    public reset(obj: Object, newState: Object) : Object
 }

--- a/src/json-patch-queue-synchronous.js
+++ b/src/json-patch-queue-synchronous.js
@@ -66,7 +66,7 @@ JSONPatchQueueSynchronous.prototype.receive = function(versionedJsonPatch, apply
 	// consecutive new version
 		while( consecutivePatch ){// process consecutive patch(-es)
 			this.version++;
-			apply(this.obj, consecutivePatch);
+			this.obj = apply(this.obj, consecutivePatch);
 			consecutivePatch = this.waiting.shift();
 		}
 	} else {

--- a/src/json-patch-queue-synchronous.js
+++ b/src/json-patch-queue-synchronous.js
@@ -114,14 +114,13 @@ JSONPatchQueueSynchronous.getPropertyByJsonPointer = function(obj, pointer) {
 
 /**
  * Reset queue internals and object to new, given state
- * @param obj object to apply new state to
  * @param newState versioned object representing desired state along with versions
  */
-JSONPatchQueueSynchronous.prototype.reset = function(obj, newState){
+JSONPatchQueueSynchronous.prototype.reset = function(newState){
 	this.version = JSONPatchQueueSynchronous.getPropertyByJsonPointer(newState, this.versionPath);
 	this.waiting = [];
 	var patch = [{ op: "replace", path: "", value: newState }];
-	return this.obj = this.apply(obj, patch);
+	return this.obj = this.apply(this.obj, patch);
 };
 
 if(typeof module !== 'undefined') {

--- a/src/json-patch-queue.js
+++ b/src/json-patch-queue.js
@@ -130,14 +130,13 @@ JSONPatchQueue.getPropertyByJsonPointer = function(obj, pointer) {
 
 /**
  * Reset queue internals and object to new, given state
- * @param obj object to apply new state to
  * @param newState versioned object representing desired state along with versions
  */
-JSONPatchQueue.prototype.reset = function(obj, newState){
+JSONPatchQueue.prototype.reset = function(newState){
 	this.remoteVersion = JSONPatchQueue.getPropertyByJsonPointer(newState, this.remotePath);
 	this.waiting = [];
 	var patch = [{ op: "replace", path: "", value: newState }];
-	return this.obj = this.apply(obj, patch);
+	return this.obj = this.apply(this.obj, patch);
 };
 
 if(typeof module !== 'undefined') {

--- a/src/json-patch-queue.js
+++ b/src/json-patch-queue.js
@@ -1,7 +1,7 @@
 /**
  * JSON Patch Queue for asynchronous operations, and asynchronous networking.
  * version: 2.0.1
- * @param {Object} Obj The target object where patches are applied
+ * @param {Object} obj The target object where patches are applied
  * @param {Array<JSON-Pointer>} versionPaths JSON-Pointers to version numbers [local, remote]
  * @param {function} apply    apply(JSONobj, JSONPatchSequence) function to apply JSONPatch to object.
  * @param {Boolean} [purist]       If set to true adds test operation before replace.
@@ -55,7 +55,6 @@ JSONPatchQueue.prototype.remoteVersion = 0;
 /**
  * Process received versioned JSON Patch
  * Applies or adds to queue.
- * @param  {Object} obj                   object to apply patches to
  * @param  {JSONPatch} versionedJsonPatch patch to be applied
  * @param  {Function} [applyCallback]     optional `function(object, consecutivePatch)` to be called when applied, if not given #apply will be called
  */
@@ -78,7 +77,7 @@ JSONPatchQueue.prototype.receive = function(versionedJsonPatch, applyCallback){
 	// consecutive new version
 		while( consecutivePatch ){// process consecutive patch(-es)
 			this.remoteVersion++;
-			apply(this.obj, consecutivePatch);
+			this.obj = apply(this.obj, consecutivePatch);
 			consecutivePatch = this.waiting.shift();
 		}
 	} else {

--- a/test/spec/asyncVersioningSpec.js
+++ b/test/spec/asyncVersioningSpec.js
@@ -2,7 +2,7 @@ if(typeof JSONPatchQueue === 'undefined') {
   JSONPatchQueue = require('../../src/index').JSONPatchQueue;
 }
 
-var obj;
+var obj = {foo: 1, baz: [{qux: 'hello'}]};
 
 
 describe("JSONPatchQueue instance", function () {
@@ -14,20 +14,17 @@ describe("JSONPatchQueue instance", function () {
 
   describe('when reset', function () {
     it('should set remote version to value given', function () {
-      var obj = {};
       var queue = new JSONPatchQueue(obj, ["/local","/remote"],function(){});
       queue.reset(obj, {local: 1, remote: 2});
       expect(queue.remoteVersion).toEqual(2);
     });
     it('should set remote version to value given even with complex version path', function () {
-      var obj = {};
       var queue = new JSONPatchQueue(obj, ["/v/local","/v/remote"],function(){});
       queue.reset(obj, {v: {local: 1, remote: 2}});
       expect(queue.remoteVersion).toEqual(2);
     });
     it('should apply big replace patch to obj', function () {
       var appliedPatch;
-      var obj = {};
       var queue = new JSONPatchQueue(obj, ["/local","/remote"], function apply(obj, patches){
         appliedPatch = patches;
       });
@@ -41,7 +38,7 @@ describe("JSONPatchQueue instance", function () {
 
   describe("when receives a Versioned JSON Patch", function () {
     var queue, applyPatch;
-    var obj = {};
+    
     beforeEach(function () {
       applyPatch = jasmine.createSpy("applyPatch");
       queue = new JSONPatchQueue(obj, ["/local","/remote"], function(){
@@ -60,13 +57,12 @@ describe("JSONPatchQueue instance", function () {
       ];
 
       beforeEach(function () {
-        queue.obj = {foo: 1, baz: [{qux: 'hello'}]};
         queue.receive(versionedJSONPatch3);
       });
 
       it('should not apply given JSON Patch sequence', function() {
         expect(applyPatch).not.toHaveBeenCalled()
-        expect(queue.obj).toEqual({foo: 1, baz: [{qux: 'hello'}]})
+        expect(obj).toEqual({foo: 1, baz: [{qux: 'hello'}]})
       });
       it('should place JSON Patch sequence in `.waiting` array, according to versions distance', function() {
         expect(queue.waiting).toContain([
@@ -112,25 +108,23 @@ describe("JSONPatchQueue instance", function () {
       ];
 
       beforeEach(function () {
-        queue.obj = {foo: 1, baz: [{qux: 'hello'}]};
         //add something to the queue
         queue.receive(versionedJSONPatch2);
         queue.receive(versionedJSONPatch3);
         // receive consecutive patch
         queue.receive(versionedJSONPatch1);
-
       });
 
       it('should apply given JSON Patch sequence', function() {
-        expect(applyPatch).toHaveBeenCalledWith(queue.obj, [{op: 'replace', path: '/baz', value: 'smth'}]);
-        expect(applyPatch.calls.argsFor(0)).toEqual([queue.obj, [{op: 'replace', path: '/baz', value: 'smth'}]]);
+        expect(applyPatch).toHaveBeenCalledWith(obj, [{op: 'replace', path: '/baz', value: 'smth'}]);
+        expect(applyPatch.calls.argsFor(0)).toEqual([obj, [{op: 'replace', path: '/baz', value: 'smth'}]]);
       });
       it('should apply queued, consecutive Patch sequences', function() {
         expect(applyPatch.calls.count()).toEqual(3);
         expect(applyPatch.calls.allArgs()).toEqual([
-          [queue.obj, [{op: 'replace', path: '/baz', value: 'smth'}]],// JSONPatch1
-          [queue.obj, [{op: 'add', path: '/bar', value: [1, 2, 3]}]],// JSONPatch2
-          [queue.obj, [{op: 'replace', path: '/bool', value: false}]]// JSONPatch3
+          [obj, [{op: 'replace', path: '/baz', value: 'smth'}]],// JSONPatch1
+          [obj, [{op: 'add', path: '/bar', value: [1, 2, 3]}]],// JSONPatch2
+          [obj, [{op: 'replace', path: '/bool', value: false}]]// JSONPatch3
         ]);
       });
       it('should update `remoteVersion` accordingly', function() {

--- a/test/spec/asyncVersioningSpec.js
+++ b/test/spec/asyncVersioningSpec.js
@@ -2,9 +2,6 @@ if(typeof JSONPatchQueue === 'undefined') {
   JSONPatchQueue = require('../../src/index').JSONPatchQueue;
 }
 
-var obj = {foo: 1, baz: [{qux: 'hello'}]};
-
-
 describe("JSONPatchQueue instance", function () {
   it('should be created with versions 0,0 by default', function() {
     var queue = new JSONPatchQueue({}, ["/local","/remote"],function(){});
@@ -14,23 +11,26 @@ describe("JSONPatchQueue instance", function () {
 
   describe('when reset', function () {
     it('should set remote version to value given', function () {
+      var obj = {};
       var queue = new JSONPatchQueue(obj, ["/local","/remote"],function(){});
-      queue.reset(obj, {local: 1, remote: 2});
+      queue.reset({local: 1, remote: 2});
       expect(queue.remoteVersion).toEqual(2);
     });
     it('should set remote version to value given even with complex version path', function () {
+      var obj = {};
       var queue = new JSONPatchQueue(obj, ["/v/local","/v/remote"],function(){});
-      queue.reset(obj, {v: {local: 1, remote: 2}});
+      queue.reset({v: {local: 1, remote: 2}});
       expect(queue.remoteVersion).toEqual(2);
     });
     it('should apply big replace patch to obj', function () {
       var appliedPatch;
+      var obj = {};
       var queue = new JSONPatchQueue(obj, ["/local","/remote"], function apply(obj, patches){
         appliedPatch = patches;
       });
       var newState = {local: 1, remote: 2, name: 'newname'};
 
-      queue.reset(obj, newState);
+      queue.reset(newState);
 
       expect(appliedPatch).toEqual([{op: 'replace', path: '', value: newState}]);
     });
@@ -38,7 +38,7 @@ describe("JSONPatchQueue instance", function () {
 
   describe("when receives a Versioned JSON Patch", function () {
     var queue, applyPatch;
-    
+    var obj = {foo: 1, baz: [{qux: 'hello'}]};
     beforeEach(function () {
       applyPatch = jasmine.createSpy("applyPatch");
       queue = new JSONPatchQueue(obj, ["/local","/remote"], function(){
@@ -113,6 +113,7 @@ describe("JSONPatchQueue instance", function () {
         queue.receive(versionedJSONPatch3);
         // receive consecutive patch
         queue.receive(versionedJSONPatch1);
+
       });
 
       it('should apply given JSON Patch sequence', function() {

--- a/test/spec/asyncVersioningSpec.js
+++ b/test/spec/asyncVersioningSpec.js
@@ -46,6 +46,7 @@ describe("JSONPatchQueue instance", function () {
       applyPatch = jasmine.createSpy("applyPatch");
       queue = new JSONPatchQueue(obj, ["/local","/remote"], function(){
         applyPatch.apply(this, arguments);
+        return arguments[0]
       });
     });
 

--- a/test/spec/synchronousVersioningSpec.js
+++ b/test/spec/synchronousVersioningSpec.js
@@ -1,8 +1,6 @@
 if(typeof JSONPatchQueueSynchronous === 'undefined') {
   JSONPatchQueueSynchronous = require('../../src/index').JSONPatchQueueSynchronous;
 }
-var obj = {foo: 1, baz: [{qux: 'hello'}]};
-
 
 describe("JSONPatchQueueSynchronous instance", function () {
   it('should be created with version 0 by default', function() {
@@ -12,25 +10,28 @@ describe("JSONPatchQueueSynchronous instance", function () {
 
   describe('when reset', function () {
     it('should set remote version to value given', function () {
+      var obj = {};
       var queue = new JSONPatchQueueSynchronous(obj, "/version",function(){});
-      queue.reset(obj, {version: 1});
+      queue.reset({version: 1});
       expect(queue.version).toEqual(1);
     });
     it('should set remote version to value given even with complex version path', function () {
 
+      var obj = {};
       var queue = new JSONPatchQueueSynchronous(obj, "/v/version",function(){});
-      queue.reset({}, {v: {version: 1}});
+      queue.reset({v: {version: 1}});
       expect(queue.version).toEqual(1);
     });
     it('should apply big replace patch to obj', function () {
       var appliedPatch;
+      var obj = {};
       var queue = new JSONPatchQueueSynchronous(obj, "/version",function apply(obj, patches){
         appliedPatch = patches;
         return obj;
       });
       var newState = {version: 1, name: 'newname'};
 
-      queue.reset({}, newState);
+      queue.reset(newState);
 
       expect(appliedPatch).toEqual([{op: 'replace', path: '', value: newState}]);
     });
@@ -38,6 +39,7 @@ describe("JSONPatchQueueSynchronous instance", function () {
 
   describe("when receives a Versioned JSON Patch", function () {
     var queue, applyPatch;
+    var obj = {foo: 1, baz: [{qux: 'hello'}]}
     beforeEach(function () {
       applyPatch = jasmine.createSpy("applyPatch");
       queue = new JSONPatchQueueSynchronous(obj, "/version",function(){

--- a/test/spec/synchronousVersioningSpec.js
+++ b/test/spec/synchronousVersioningSpec.js
@@ -29,6 +29,7 @@ describe("JSONPatchQueueSynchronous instance", function () {
       var obj = {};
       var queue = new JSONPatchQueueSynchronous(obj, "/version",function apply(obj, patches){
         appliedPatch = patches;
+        return obj;
       });
       var newState = {version: 1, name: 'newname'};
 
@@ -44,6 +45,7 @@ describe("JSONPatchQueueSynchronous instance", function () {
       applyPatch = jasmine.createSpy("applyPatch");
       queue = new JSONPatchQueueSynchronous({}, "/version",function(){
         applyPatch.apply(this, arguments);
+        return arguments[0];
       });
     });
 
@@ -112,6 +114,7 @@ describe("JSONPatchQueueSynchronous instance", function () {
       });
 
       it('should apply given JSON Patch sequence', function() {
+        debugger
         expect(applyPatch).toHaveBeenCalledWith(queue.obj, [{op: 'replace', path: '/baz', value: 'smth'}]);
         expect(applyPatch.calls.argsFor(0)).toEqual([queue.obj, [{op: 'replace', path: '/baz', value: 'smth'}]]);
       });


### PR DESCRIPTION
As opposed to per-`receive`-function-call.

Fixes: https://github.com/Palindrom/JSON-Patch-Queue/issues/6